### PR TITLE
SetProjectName Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /node_modules
 .idea/
 /SampleBaseProject
+/MyProject
 
 /typescript/*.js
 /coffeescript/*.js

--- a/GrammarSamples/CustomProjectName.txt
+++ b/GrammarSamples/CustomProjectName.txt
@@ -1,0 +1,6 @@
+start
+    Connect("ds111963.mlab.com:11963/emaily-dev", "adilimtiaz", "password123");
+    SetProjectBaseDir("/Users/adilimtiaz/WebstormProjects/chevrotain/examples/tutorial");
+    SetProjectName("customProjectName");
+    CreateSchema{SchemaName:"ATable", Fields: {"ID":"Number", "StudentName":"String"}};
+end

--- a/GrammerDef.txt
+++ b/GrammerDef.txt
@@ -13,6 +13,9 @@ endStmt
 setProjectBaseDir
     : setProjectBaseDir("Path");
 
+setProjectName
+    : setProjectName("Name");
+
 statement
     : createSchemaStmt | insertSchemastmt
 

--- a/ast/ast.js
+++ b/ast/ast.js
@@ -17,6 +17,9 @@ const parserInstance = new Parser([]);
 // The base visitor class can be accessed via the a parser instance.
 const BaseDSLVisitor = parserInstance.getBaseCstVisitorConstructorWithDefaults();
 
+const ProjectNameStmtAstType =  "SET_PROJECT_NAME_STMT";
+const DefaultProjectNameAst = {type: ProjectNameStmtAstType, name: "myProject"};
+
 class DSLToAstVisitor extends BaseDSLVisitor {
     constructor() {
         super();
@@ -27,6 +30,13 @@ class DSLToAstVisitor extends BaseDSLVisitor {
         // No need to visit start or end ast they are only used to validate program syntax
         let connectStmtAst = this.visit(ctx.connectStatement);
         let setProjectBaseDirStmtAst = this.visit(ctx.setProjectBaseDirStmt);
+        let setProjectNameStmtAst;
+        if(ctx.setProjectNameStmt) {
+            setProjectNameStmtAst = this.visit(ctx.setProjectNameStmt);
+        } else {
+            setProjectNameStmtAst = DefaultProjectNameAst;
+        }
+
         let schemas = [];
         ctx.createSchemaStatement.forEach((statement) => {
             const schema = this.createSchemaStatement(statement.children);
@@ -38,6 +48,7 @@ class DSLToAstVisitor extends BaseDSLVisitor {
             type: "PROGRAM",
             connectStmtAst: connectStmtAst,
             setProjectBaseDirStmtAst: setProjectBaseDirStmtAst,
+            setProjectNameStmtAst: setProjectNameStmtAst,
             createSchemaStmtAst: createSchemaStmtAst
         }
     }
@@ -56,6 +67,13 @@ class DSLToAstVisitor extends BaseDSLVisitor {
         }
     }
 
+    setProjectNameStmt(ctx){
+        let projectName = ctx.StringLiteral[0].image;
+        return {
+            type: ProjectNameStmtAstType,
+            name: JSON.parse(projectName)
+        }
+    }
 
     connectStatement(ctx) {
         let MongoURI = ctx.MongoURI[0].image;

--- a/ast/ast_spec.js
+++ b/ast/ast_spec.js
@@ -62,6 +62,16 @@ describe("AST output tests", () => {
             "type": "SET_PROJECT_BASE_DIR_STMT"
         };
 
+        let expectDefaultProjectNameStmtAst = {
+            "name": "myProject",
+            "type": "SET_PROJECT_NAME_STMT"
+        };
+
+        let expectSetProjectNameStmtAst = {
+            "name": "customProjectName",
+            "type": "SET_PROJECT_NAME_STMT"
+        };
+
         it("Can create expected ast output from JustOneCreateSchemaStmt.txt", () => {
             let inputText = fs.readFileSync(path.join(__dirname ,'../GrammarSamples/JustOneCreateSchemaStmt.txt'), 'utf8');
             const ast = toAstVisitor(inputText);
@@ -74,6 +84,24 @@ describe("AST output tests", () => {
                 type: "PROGRAM",
                 connectStmtAst: expectedConnectStmtAst,
                 setProjectBaseDirStmtAst: expectSetProjectBaseDirStmtAst,
+                setProjectNameStmtAst: expectDefaultProjectNameStmtAst,
+                createSchemaStmtAst: expectedCreateSchemaStmtAst
+            });
+        });
+
+        it("Can create expected ast output for custom Project Name", () => {
+            let inputText = fs.readFileSync(path.join(__dirname ,'../GrammarSamples/CustomProjectName.txt'), 'utf8');
+            const ast = toAstVisitor(inputText);
+
+            let expectedSchemas = [];
+            expectedSchemas.push(expectedSchemaStmtJSON1);
+            let expectedCreateSchemaStmtAst = {schemas : expectedSchemas, type: "CREATE_SCHEMA_STMT"};
+
+            expect(ast).to.deep.equal({
+                type: "PROGRAM",
+                connectStmtAst: expectedConnectStmtAst,
+                setProjectBaseDirStmtAst: expectSetProjectBaseDirStmtAst,
+                setProjectNameStmtAst: expectSetProjectNameStmtAst,
                 createSchemaStmtAst: expectedCreateSchemaStmtAst
             });
         });
@@ -90,6 +118,7 @@ describe("AST output tests", () => {
                 type: "PROGRAM",
                 connectStmtAst: expectedConnectStmtAst,
                 setProjectBaseDirStmtAst: expectSetProjectBaseDirStmtAst,
+                setProjectNameStmtAst: expectDefaultProjectNameStmtAst,
                 createSchemaStmtAst: expectedCreateSchemaStmtAst
             });
         })

--- a/lexer/lexer.js
+++ b/lexer/lexer.js
@@ -31,6 +31,7 @@ const WindowsPath = createToken({
 });
 
 const SetProjectBaseDir = createToken({name: "SetProjectBaseDir", pattern: /SetProjectBaseDir/});
+const SetProjectName = createToken({name: "SetProjectName", pattern: /SetProjectName/});
 const End = createToken({name: "End", pattern: /end/ , longer_alt: StringLiteral});
 const ConnectLiteral = createToken({name: "ConnectLiteral", pattern: /Connect/ , longer_alt: StringLiteral});
 const CreateSchema = createToken({name: "CreateSchema", pattern: /CreateSchema/, longer_alt: StringLiteral});
@@ -66,6 +67,7 @@ const allTokens = [
     Start,
     End,
     SetProjectBaseDir,
+    SetProjectName,
     ConnectLiteral,
     EndOfLine,
     CreateSchema,

--- a/lexer/lexer_spec.js
+++ b/lexer/lexer_spec.js
@@ -36,6 +36,18 @@ describe("Lexing tests", () => {
             // expect(tokens[0].image).to.equal("")
         });
 
+        it("Can Lex a Project Name", () => {
+            let projectNameSample = "SetProjectName(\"testProjectName\");";
+            let lexingResult = lex(projectNameSample);
+            console.log(JSON.stringify(lexingResult.errors));
+
+            let tokens = lexingResult.tokens;
+
+            expect(lexingResult.errors).to.be.empty;
+            expect(tokenMatcher(tokens[0], tokenVocabulary.SetProjectName)).to.be.true;
+            expect(tokenMatcher(tokens[2], tokenVocabulary.StringLiteral)).to.be.true;
+        });
+
         it("Can Lex a DB URL", () => {
             let dbUrl = "ds111963.mlab.com:11963/emaily-dev";
             let lexingResult = lex(dbUrl);

--- a/lib/generators.js
+++ b/lib/generators.js
@@ -32,12 +32,12 @@ function createMongoURI(mongoURI, dbUsername, dbPassword) {
  * @param {string} mongoURI
  * @param {string} projectBasePath
  */
-function generateSampleIndexFile(mongoURI, projectBasePath) {
+function generateSampleIndexFile(mongoURI, projectBasePath, projectName) {
     let indexFileText = fileTools.loadTemplateSync('indexTemplate.js');
     indexFileText = indexFileText.replace(/{mongoURI}/, JSON.stringify(mongoURI));
-    let pathToWrite = path.join(projectBasePath, "./SampleBaseProject/index.js");
+    let pathToWrite = path.join(projectBasePath, "./" + projectName + "/index.js");
 
-    fileTools.createDirIfIsNotDefined(projectBasePath, "SampleBaseProject"); //Hard coded to write to this path for now
+    fileTools.createDirIfIsNotDefined(projectBasePath, projectName); //Hard coded to write to this path for now
     fileTools.writeFile(pathToWrite, indexFileText);
 }
 
@@ -47,7 +47,7 @@ function generateSampleIndexFile(mongoURI, projectBasePath) {
  * @param {string} schemaName
  * @param {array} schemaFields
  */
-function generateModel(projectBasePath, schemaName, schemaFields) {
+function generateModel(projectBasePath, projectName, schemaName, schemaFields) {
     let fieldsText = getFieldsForModelTemplate(schemaFields);
     let fileName = schemaName + 'Schema'; //carSchema
 
@@ -56,9 +56,9 @@ function generateModel(projectBasePath, schemaName, schemaFields) {
     modelFileText = modelFileText.replace(/{schemaName}/g, schemaName);
     modelFileText = modelFileText.replace(/{fields}/, fieldsText);
 
-    let pathToWrite = path.join(projectBasePath, './SampleBaseProject/models/' + fileName + '.js');
+    let pathToWrite = path.join(projectBasePath, './' + projectName + '/models/' + fileName + '.js');
 
-    fileTools.createDirIfIsNotDefined(projectBasePath, './SampleBaseProject/models');
+    fileTools.createDirIfIsNotDefined(projectBasePath, './' + projectName + '/models');
     fileTools.writeFile(pathToWrite, modelFileText);
 }
 
@@ -67,13 +67,13 @@ function generateModel(projectBasePath, schemaName, schemaFields) {
  * Generate a README.md file at SampleProjectBase/README.md
  * @param {string} Base Project Path
  */
-function generatePackageJSONAndReadme(projectBasePath) {
+function generatePackageJSONAndReadme(projectBasePath, projectName) {
     let packageFileText = fileTools.loadTemplateSync('package.json');
     let readmeFIleText = fileTools.loadTemplateSync('README.md');
-    let pathToWrite = path.join(projectBasePath, './SampleBaseProject/package.json');
-    let readmePath = path.join(projectBasePath, './SampleBaseProject/README.md');
+    let pathToWrite = path.join(projectBasePath, './' + projectName + '/package.json');
+    let readmePath = path.join(projectBasePath, './' + projectName + '/README.md');
 
-    fileTools.createDirIfIsNotDefined(projectBasePath, './SampleBaseProject');
+    fileTools.createDirIfIsNotDefined(projectBasePath, './' + projectName + '');
     fileTools.writeFile(pathToWrite, packageFileText);
     fileTools.writeFile(readmePath, readmeFIleText);
 }

--- a/lib/generators.js
+++ b/lib/generators.js
@@ -37,7 +37,7 @@ function generateSampleIndexFile(mongoURI, projectBasePath, projectName) {
     indexFileText = indexFileText.replace(/{mongoURI}/, JSON.stringify(mongoURI));
     let pathToWrite = path.join(projectBasePath, "./" + projectName + "/index.js");
 
-    fileTools.createDirIfIsNotDefined(projectBasePath, projectName); //Hard coded to write to this path for now
+    fileTools.createDirIfIsNotDefined(projectBasePath, projectName);
     fileTools.writeFile(pathToWrite, indexFileText);
 }
 

--- a/main.js
+++ b/main.js
@@ -12,14 +12,15 @@ let setProjectBaseDirStmtAst = programAst.setProjectBaseDirStmtAst;
 let createSchemaStatementAst = programAst.createSchemaStmtAst;
 
 let projectBaseDir = setProjectBaseDirStmtAst.path;
+let projectName = programAst.setProjectNameStmtAst.name;
 
 let mongoURI = generators.createMongoURI(connectStmtAst.mongoURI, connectStmtAst.dbUsername, connectStmtAst.dbPassword);
-generators.generateSampleIndexFile(mongoURI, projectBaseDir);
-generators.generatePackageJSONAndReadme(projectBaseDir);
+generators.generateSampleIndexFile(mongoURI, projectBaseDir, projectName);
+generators.generatePackageJSONAndReadme(projectBaseDir, projectName);
 
 let schemasToCreate = createSchemaStatementAst.schemas;
 schemasToCreate.forEach(schema => {
-    generators.generateModel(projectBaseDir, schema.schemaName, schema.fields);
+    generators.generateModel(projectBaseDir, projectName, schema.schemaName, schema.fields);
 });
 
 

--- a/parser/parser.js
+++ b/parser/parser.js
@@ -19,6 +19,7 @@ class Parser extends chevrotainParser {
            $.SUBRULE($.startStmt);
            $.SUBRULE($.connectStatement);
            $.SUBRULE($.setProjectBaseDirStmt);
+           $.OPTION(() => {$.SUBRULE($.setProjectNameStmt); });
            $.MANY(() => { $.SUBRULE($.createSchemaStatement); });
            $.SUBRULE($.endStmt);
         });
@@ -34,6 +35,14 @@ class Parser extends chevrotainParser {
                 {ALT: () => $.CONSUME($.tokensMap.UnixPath)},
                 {ALT: () => $.CONSUME($.tokensMap.WindowsPath)}
             ], {LABEL: "path"});
+            $.CONSUME($.tokensMap.RRound);
+            $.CONSUME($.tokensMap.Semicolon);
+        });
+
+        $.RULE("setProjectNameStmt", () =>{
+            $.CONSUME($.tokensMap.SetProjectName);
+            $.CONSUME($.tokensMap.LRound);
+            $.CONSUME1($.tokensMap.StringLiteral);
             $.CONSUME($.tokensMap.RRound);
             $.CONSUME($.tokensMap.Semicolon);
         });


### PR DESCRIPTION
Implementation of setProjectName allows you to specify the project name, and subsequently, the folder that the output is generated in. I've tested the parser, lexer, and ast; seems to work perfectly.

Template index.js currently does not use the new Project Name.
Tests currently fail but not due to any changes from this (main branch also down)